### PR TITLE
fix: feature-section-dark-mode

### DIFF
--- a/src/components/aboutusSection/desktop/index.tsx
+++ b/src/components/aboutusSection/desktop/index.tsx
@@ -23,8 +23,13 @@ export default function AboutUsSection() {
                             <p className="text-base text-gray-500 dark:text-white">{t('featuresSection.subtitle')}</p>
                             <div className="flex flex-col">
                                 {features.map((element: Features, index: number) => (
-                                    <div className="flex flex-row items-start gap-4 px-4 py-8 rounded-md cursor-pointer group hover:bg-gray-100" key={index} onMouseEnter={() => { handlePress(element.imagePreview) }}>
-                                        <Image src={element.icon} width={40} className="!opacity-50 group-hover:!opacity-100" />
+                                    <div
+                                        role="presentation"
+                                        className="flex flex-row items-start gap-4 px-4 py-8 rounded-md cursor-pointer group hover:bg-gray-100 dark:hover:bg-white"
+                                        key={index}
+                                        onMouseEnter={() => { handlePress(element.imagePreview) }}
+                                    >
+                                        <img alt={element.title} src={element.icon} width={40} className="opacity-50 group-hover:opacity-100 dark:invert dark:opacity-80 dark:group-hover:invert-0 dark:group-hover:opacity-100 " />
                                         <div className="flex flex-col justify-center gap-2">
                                             <h1 className="font-bold group-hover:text-gray-600 dark:group-hover:text-black">{element.title}</h1>
                                             <p className="text-gray-700 group-hover:text-black dark:text-white">{element.description}</p>

--- a/src/components/partials/navbar/desktop/index.tsx
+++ b/src/components/partials/navbar/desktop/index.tsx
@@ -3,6 +3,7 @@ import { NavItemsProps } from "../../../../common/types";
 import CenteredLayout from "../../../ui/centredLayout";
 import ThemeToggler from "../../../shared/themeToggler";
 import LanguageDropdown from "../../../shared/languageDorpdown";
+import { scrollToTop } from "../../../../common/utils";
 
 export default function DesktopNavBar({ navItems }: Readonly<{ navItems: NavItemsProps[] }>) {
 
@@ -18,7 +19,7 @@ export default function DesktopNavBar({ navItems }: Readonly<{ navItems: NavItem
                         {
                             navItems.map((element: NavItemsProps, index: number) =>
                                 <li key={index} className='py-4'>
-                                    <Link href={element.link} className='block text-gray-900 hover:text-blue-700' >
+                                    <Link href={element.link} onClick={() => scrollToTop()} className='block text-gray-900 hover:text-blue-700' >
                                         {element.label}
                                     </Link>
                                 </li>


### PR DESCRIPTION
Adjust icon colors to be visible in dark mode and on hover. Additionally, implement a scroll-to-top function for the NavLink, so the page scrolls to the top when navigating between views.